### PR TITLE
OCD-1050: added text to resources page

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Version TBD
+_Date TBD_
+
+### Features Added
+* Added text to Resources page under API Section
+
+### Bugs Fixed
+
+--- 
+
 ## Version 6.0.0
 _15 November 2016_
 
@@ -9,7 +19,6 @@ _15 November 2016_
 * Addition of Previous Product Owner capability
 * Improved text on Resources page
 * Updated filter UI
-* Added text to Resources page under API Section
 
 ### Bugs fixed
 * Merge dialog closes on submit

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@ _15 November 2016_
 * Addition of Previous Product Owner capability
 * Improved text on Resources page
 * Updated filter UI
+* Added text to Resources page under API Section
 
 ### Bugs fixed
 * Merge dialog closes on submit

--- a/app/resources/resources.html
+++ b/app/resources/resources.html
@@ -113,7 +113,17 @@
     </div>
     <div class="row">
       <div class="col-sm-7">
-        <p>The ONC CHPL API provides programmatic access to ONC published data on Certified Health IT Products. ONC CHPL's API includes methods for retrieving a subset of our statistical data and the metadata that describes it.</p>
+        <p>The ONC CHPL API provides programmatic access to ONC published data on Certified Health IT Products. ONC CHPL's API includes methods for retrieving a subset of our statistical data and the metadata that describes it. Users must complete the CHPL API registration. After completing the CHPL API registration, the user will be given a unique 32-character API key. This API key will also be emailed to the user.
+      	</p>
+      	<p>
+      	This API key must be used when making a call to the CHPL API. For example, if you wanted to implement the /search API with the &#39;searchTerm&#39; parameter set as &#39;Epic&#39;, you would make the following call (switching out the key in the URL for your key):
+		<br>
+      	https://chpl.healthit.gov/rest/search/?api_key=YOURKEYHERE&searchTerm=Epic
+      	</p>
+      	<p>A sample Java application using the CHPL API can be found here:
+      	<br>
+      	https://github.com/chpladmin/sample-application
+      	</p>
       </div>
       <div class="col-sm-4 col-sm-offset-1">
         <div>

--- a/app/resources/resources.html
+++ b/app/resources/resources.html
@@ -113,14 +113,19 @@
     </div>
     <div class="row">
       <div class="col-sm-7">
-        <p>The ONC CHPL API provides programmatic access to ONC published data on Certified Health IT Products. ONC CHPL's API includes methods for retrieving a subset of our statistical data and the metadata that describes it. Users must complete the CHPL API registration. After completing the CHPL API registration, the user will be given a unique 32-character API key. This API key will also be emailed to the user.
+        <p>
+        The ONC CHPL API provides programmatic access to ONC published data on Certified Health IT Products. ONC CHPL's API includes methods for retrieving a subset of our statistical data and the metadata that describes it. Users must complete the CHPL API registration. After completing the CHPL API registration, the user will be given a unique 32-character API key. This API key will also be emailed to the user.
       	</p>
       	<p>
-      	This API key must be used when making a call to the CHPL API. For example, if you wanted to implement the /search API with the &#8216;searchTerm&#8217; parameter set as &#8216;Epic&#8217;, you would make the following call (switching out the key in the URL for your key):
+      	This API key must be used when making a call to the CHPL API. For example, if you wanted to implement the /search API with the searchTerm parameter set as Epic, you would make the following call (switching out the key in the URL for your key):
 		<br />
-      	<pre>https://chpl.healthit.gov/rest/search/?api_key=YOURKEYHERE&searchTerm=Epic</pre> </p>
-      	<p>A sample Java application using the CHPL API can be found here:<br><a href="https://github.com/chpladmin/sample-application">https://github.com/chpladmin/sample-application
-      	</a></p>
+      	<pre>https://chpl.healthit.gov/rest/search/?api_key=YOURKEYHERE&searchTerm=Epic</pre>
+      	</p>
+      	<p>
+      	A sample Java application using the CHPL API can be found here:
+      	<br />
+      	<a href="https://github.com/chpladmin/sample-application">https://github.com/chpladmin/sample-application</a>
+      	</p>
       </div>
       <div class="col-sm-4 col-sm-offset-1">
         <div>

--- a/app/resources/resources.html
+++ b/app/resources/resources.html
@@ -119,7 +119,8 @@
       	This API key must be used when making a call to the CHPL API. For example, if you wanted to implement the /search API with the &#8216;searchTerm&#8217; parameter set as &#8216;Epic&#8217;, you would make the following call (switching out the key in the URL for your key):
 		<br />
       	<pre>https://chpl.healthit.gov/rest/search/?api_key=YOURKEYHERE&searchTerm=Epic</pre> </p>
-      	<p>A sample Java application using the CHPL API can be found here:<br><a href="https://github.com/chpladmin/sample-application">https://github.com/chpladmin/sample-application</a></p>
+      	<p>A sample Java application using the CHPL API can be found here:<br><a href="https://github.com/chpladmin/sample-application">https://github.com/chpladmin/sample-application
+      	</a></p>
       </div>
       <div class="col-sm-4 col-sm-offset-1">
         <div>

--- a/app/resources/resources.html
+++ b/app/resources/resources.html
@@ -116,14 +116,10 @@
         <p>The ONC CHPL API provides programmatic access to ONC published data on Certified Health IT Products. ONC CHPL's API includes methods for retrieving a subset of our statistical data and the metadata that describes it. Users must complete the CHPL API registration. After completing the CHPL API registration, the user will be given a unique 32-character API key. This API key will also be emailed to the user.
       	</p>
       	<p>
-      	This API key must be used when making a call to the CHPL API. For example, if you wanted to implement the /search API with the &#39;searchTerm&#39; parameter set as &#39;Epic&#39;, you would make the following call (switching out the key in the URL for your key):
-		<br>
-      	https://chpl.healthit.gov/rest/search/?api_key=YOURKEYHERE&searchTerm=Epic
-      	</p>
-      	<p>A sample Java application using the CHPL API can be found here:
-      	<br>
-      	https://github.com/chpladmin/sample-application
-      	</p>
+      	This API key must be used when making a call to the CHPL API. For example, if you wanted to implement the /search API with the &#8216;searchTerm&#8217; parameter set as &#8216;Epic&#8217;, you would make the following call (switching out the key in the URL for your key):
+		<br />
+      	<pre>https://chpl.healthit.gov/rest/search/?api_key=YOURKEYHERE&searchTerm=Epic</pre> </p>
+      	<p>A sample Java application using the CHPL API can be found here:<br><a href="https://github.com/chpladmin/sample-application">https://github.com/chpladmin/sample-application</a></p>
       </div>
       <div class="col-sm-4 col-sm-offset-1">
         <div>


### PR DESCRIPTION
Added multiple paragraph tags to resources page with new text per requirement in OCD-1050. I chose to use paragraph over break in most cases because the consensus online is that it is more consistent with styling. See here:
http://stackoverflow.com/questions/13688158/when-to-use-p-vs-br

Screenshot of appearance after change with changes highlighted:
![ocd-1050change](https://cloud.githubusercontent.com/assets/4240975/20403900/9fecf3c4-acd0-11e6-9aef-bc705add400a.jpg)
