### PR TITLE
OCD-1412: Pending surveillance UX

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,14 @@
 # Release Notes
 
-OCD-1412: Pending Surveillance UX
-
----
-
 ## Version TBD
 _Date TBD_
 
 ### New features
 * Added "Transparency Attestations" for Developers Collection
 * Tweaked "CMS ID Lookup" download to have a filename
+* Pending Surveillance UX changed for better responsiveness
+* Return to "blue screen with buttons" on "Logo" click
+* Allow "Details" button on search results to open in new window
 
 ---
 

--- a/src/app/admin/components/certifiedProduct/listing/inspect.controller.js
+++ b/src/app/admin/components/certifiedProduct/listing/inspect.controller.js
@@ -180,7 +180,15 @@
                 .then(function (result) {
                     $uibModalInstance.close({status: 'confirmed', developerCreated: vm.developerChoice === 'create', developer: result.developer});
                 }, function (error) {
-                    vm.errorMessages = error.data.errorMessages;
+                    if (error.data.contact) {
+                        $uibModalInstance.close({
+                            contact: error.data.contact,
+                            objectId: error.data.objectId,
+                            status: 'resolved',
+                        });
+                    } else {
+                        vm.errorMessages = error.data.errorMessages;
+                    }
                 });
         }
 

--- a/src/app/admin/components/certifiedProduct/management.directive.js
+++ b/src/app/admin/components/certifiedProduct/management.directive.js
@@ -243,30 +243,20 @@
             angular.forEach(vm.massReject, function (value, key) {
                 if (value) {
                     idsToReject.push(parseInt(key));
+                    clearPendingListing(parseInt(key));
+                    delete(vm.massReject[key]);
                 }
             });
             commonService.massRejectPendingListings(idsToReject)
-                .then(function () {
-                    angular.forEach(vm.massReject, function (value, key) {
-                        if (value) {
-                            clearPendingListing(parseInt(key));
-                            delete(vm.massReject[key]);
-                        }
-                    });
-                }, function (error) {
-                    angular.forEach(vm.massReject, function (value, key) {
-                        if (value) {
-                            clearPendingListing(parseInt(key));
-                            delete(vm.massReject[key]);
-                        }
-                    });
-                    if (error.data.errors && error.data.errors.length > 0) {
-                        vm.uploadingListingsMessages = error.data.errors.map(function (error) {
-                            var ret = 'Product with ID: "' + error.objectId + '" has already been resolved by "' + error.contact.firstName + ' ' + error.contact.lastName + '"';
-                            return ret;
-                        });
-                    }
-                });
+                .then(function () {},
+                      function (error) {
+                          if (error.data.errors && error.data.errors.length > 0) {
+                              vm.uploadingListingsMessages = error.data.errors.map(function (error) {
+                                  var ret = 'Product with ID: "' + error.objectId + '" has already been resolved by "' + error.contact.firstName + ' ' + error.contact.lastName + '"';
+                                  return ret;
+                              });
+                          }
+                      });
         }
 
         function massRejectPendingSurveillance () {
@@ -274,30 +264,20 @@
             angular.forEach(vm.massRejectSurveillance, function (value, key) {
                 if (value) {
                     idsToReject.push(parseInt(key));
+                    clearPendingSurveillance(parseInt(key));
+                    delete(vm.massRejectSurveillance[key]);
                 }
             });
             commonService.massRejectPendingSurveillance(idsToReject)
-                .then(function () {
-                    angular.forEach(vm.massRejectSurveillance, function (value, key) {
-                        if (value) {
-                            clearPendingSurveillance(parseInt(key));
-                            delete(vm.massRejectSurveillance[key]);
-                        }
-                    });
-                }, function (error) {
-                    angular.forEach(vm.massRejectSurveillance, function (value, key) {
-                        if (value) {
-                            clearPendingSurveillance(parseInt(key));
-                            delete(vm.massRejectSurveillance[key]);
-                        }
-                    });
-                    if (error.data.errors && error.data.errors.length > 0) {
-                        vm.uploadingSurveillanceMessages = error.data.errors.map(function (error) {
-                            var ret = 'Surveillance with ID: "' + error.objectId + '" has already been resolved by "' + error.contact.firstName + ' ' + error.contact.lastName + '"';
-                            return ret;
-                        });
-                    }
-                });
+                .then(function () {},
+                      function (error) {
+                          if (error.data.errors && error.data.errors.length > 0) {
+                              vm.uploadingSurveillanceMessages = error.data.errors.map(function (error) {
+                                  var ret = 'Surveillance with ID: "' + error.objectId + '" has already been resolved by "' + error.contact.firstName + ' ' + error.contact.lastName + '"';
+                                  return ret;
+                              });
+                          }
+                      });
         }
 
         function mergeDevelopers () {
@@ -589,12 +569,20 @@
                 },
                 size: 'lg',
             });
-            vm.modalInstance.result.then(function () {
-                vm.refreshPending();
-            }, function (result) {
-                if (result !== 'cancelled') {
-                    vm.refreshPending();
+            vm.modalInstance.result.then(function (result) {
+                if (result.status === 'confirmed' || result.status === 'rejected' || result.status === 'resolved') {
+                    for (var i = 0; i < vm.uploadingSurveillances.length; i++) {
+                        if (surv.id === vm.uploadingSurveillances[i].id) {
+                            vm.uploadingSurveillances.splice(i,1)
+                            vm.pendingSurveillances = vm.uploadingSurveillances.length;
+                        }
+                    }
+                    if (result.status === 'resolved') {
+                        vm.uploadingSurveillanceMessages = ['Surveillance with ID: "' + result.objectId + '" has already been resolved by "' + result.contact.firstName + ' ' + result.contact.lastName + '"'];
+                    }
                 }
+            }, function (result) {
+                $log.info('inspection: ' + result);
             });
         }
 

--- a/src/app/admin/components/certifiedProduct/management.directive.spec.js
+++ b/src/app/admin/components/certifiedProduct/management.directive.spec.js
@@ -337,15 +337,13 @@
                 expect(commonService.massRejectPendingListings).toHaveBeenCalledWith([1]);
             });
 
-            it('should reset the pending checkboxes on success', function () {
+            it('should reset the pending checkboxes', function () {
                 vm.massRejectPendingListings();
-                el.isolateScope().$digest();
                 expect(vm.massReject).toEqual({2: false});
             });
 
-            it('should remove the listings from the list of listings if rejection is successful', function () {
+            it('should remove the listings from the list of listings', function () {
                 vm.massRejectPendingListings();
-                el.isolateScope().$digest();
                 expect(vm.uploadingCps).toEqual([{id: 2}]);
             });
 
@@ -383,15 +381,13 @@
                 expect(commonService.massRejectPendingSurveillance).toHaveBeenCalledWith([1]);
             });
 
-            it('should reset the pending checkboxes on success', function () {
+            it('should reset the pending checkboxes', function () {
                 vm.massRejectPendingSurveillance();
-                el.isolateScope().$digest();
                 expect(vm.massRejectSurveillance).toEqual({2: false});
             });
 
-            it('should remove the surveillances from the list of surveillances if rejection is successful', function () {
+            it('should remove the surveillances from the list of surveillances', function () {
                 vm.massRejectPendingSurveillance();
-                el.isolateScope().$digest();
                 expect(vm.uploadingSurveillances).toEqual([{id: 2}]);
             });
 
@@ -411,6 +407,70 @@
                 vm.massRejectSurveillance[2] = false;
                 vm.massRejectSurveillance[3] = false;
                 expect(vm.getNumberOfSurveillanceToReject()).toBe(0);
+            });
+        });
+        describe('inspecting a pending Surveillance', function () {
+            var surveillanceInspectOptions;
+            beforeEach(function () {
+                vm.uploadingSurveillances = [
+                    {id: 1},
+                    {id: 2},
+                ];
+                surveillanceInspectOptions = {
+                    templateUrl: 'app/admin/components/surveillance/inspect.html',
+                    controller: 'SurveillanceInspectController',
+                    controllerAs: 'vm',
+                    animation: false,
+                    backdrop: 'static',
+                    keyboard: false,
+                    size: 'lg',
+                    resolve: {
+                        surveillance: jasmine.any(Function),
+                    },
+                };
+            });
+
+            it('should create a modal instance when a Listing is to be edited', function () {
+                expect(vm.modalInstance).toBeUndefined();
+                vm.inspectSurveillance({})
+                expect(vm.modalInstance).toBeDefined();
+            });
+
+            it('should resolve elements on inspect', function () {
+                vm.inspectSurveillance({id: 'a surveillance'})
+                expect($uibModal.open).toHaveBeenCalledWith(surveillanceInspectOptions);
+                expect(actualOptions.resolve.surveillance()).toEqual({id: 'a surveillance'});
+                el.isolateScope().$digest();
+            });
+
+            it('should remove the inspected surv on close', function () {
+                var result = {
+                    status: 'confirmed',
+                };
+                vm.inspectSurveillance(vm.uploadingSurveillances[0]);
+                vm.modalInstance.close(result);
+                expect(vm.uploadingSurveillances).toEqual([{id: 2}]);
+            });
+
+            it('should report the user who did something on resolved', function () {
+                var result = {
+                    status: 'resolved',
+                    objectId: 'id',
+                    contact: {
+                        firstName: 'fname',
+                        lastName: 'lname',
+                    },
+                };
+                vm.inspectSurveillance(vm.uploadingSurveillances[0]);
+                vm.modalInstance.close(result);
+                expect(vm.uploadingSurveillanceMessages[0]).toEqual('Surveillance with ID: "id" has already been resolved by "fname lname"');
+            });
+
+            it('should log a cancelled modal', function () {
+                var logCount = $log.info.logs.length;
+                vm.inspectSurveillance({});
+                vm.modalInstance.dismiss('cancelled');
+                expect($log.info.logs.length).toBe(logCount + 1);
             });
         });
     });

--- a/src/app/admin/components/surveillance/inspect.controller.js
+++ b/src/app/admin/components/surveillance/inspect.controller.js
@@ -34,10 +34,18 @@
                 .then(function () {
                     $uibModalInstance.close({status: 'confirmed'});
                 }, function (error) {
-                    if (error.data.messages) {
-                        vm.errorMessages = error.data.errorMessages;
+                    if (error.data.contact) {
+                        $uibModalInstance.close({
+                            contact: error.data.contact,
+                            objectId: error.data.objectId,
+                            status: 'resolved',
+                        });
                     } else {
-                        vm.errorMessages = [error.statusText];
+                        if (error.data.errorMessages) {
+                            vm.errorMessages = error.data.errorMessages;
+                        } else {
+                            vm.errorMessages = [error.statusText];
+                        }
                     }
                 });
         }
@@ -90,9 +98,17 @@
         function reject () {
             commonService.rejectPendingSurveillance(vm.surveillance.id)
                 .then(function () {
-                    $uibModalInstance.dismiss('rejected');
+                    $uibModalInstance.close({status: 'rejected'});
                 },function (error) {
-                    vm.errorMessages = [error.statusText]
+                    if (error.data.contact) {
+                        $uibModalInstance.close({
+                            contact: error.data.contact,
+                            objectId: error.data.objectId,
+                            status: 'resolved',
+                        });
+                    } else {
+                        vm.errorMessages = error.data.errorMessages;
+                    }
                 });
         }
 

--- a/src/app/search/search.controller.js
+++ b/src/app/search/search.controller.js
@@ -39,9 +39,6 @@
         ////////////////////////////////////////////////////////////////////
 
         function activate () {
-            if ($localStorage.clearResults) {
-                vm.clear();
-            }
             $scope.$on('ClearResults', function () {
                 vm.clear();
             });
@@ -60,6 +57,9 @@
             manageStorage();
             populateSearchOptions();
             restoreResults();
+            if ($localStorage.clearResults) {
+                vm.clear();
+            }
             vm.loadResults();
             setTimestamp();
         }


### PR DESCRIPTION
 * Display "previously resolved" contact information on main screen when
 confirmed/rejected from modal
 * Tweaked pending Listing resolution to display same information
 * Clicking on Logo goes to "blue screen with collections" home page