### PR TITLE
OCD-1691: Handle hexadecimal parsed ICS codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chpl",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app/admin/admin.html
+++ b/src/app/admin/admin.html
@@ -77,7 +77,7 @@
         <ai-subscription-recipients ng-if="vm.navState.screen === 'subscriptions'"
                                     acbs="vm.acbs"></ai-subscription-recipients>
         <ai-api-key admin="true" ng-if="vm.navState.screen === 'apiKeyManagement'"></ai-api-key>
-        <ai-announcements-management admin="true" ng-if="vm.navState.screen === 'announcementsManagement'"></ai-announcements-management>
+        <ai-announcements-management ng-if="vm.navState.screen === 'announcementsManagement'"></ai-announcements-management>
         <ai-cms-management admin="true" ng-if="vm.navState.screen === 'cmsManagement'"></ai-cms-management>
       </div>
     </div>

--- a/src/app/admin/components/announcements/edit.controller.js
+++ b/src/app/admin/components/announcements/edit.controller.js
@@ -7,44 +7,23 @@
     /** @ngInject */
     function AnnouncementEditController ($uibModalInstance, action, announcement, authService, commonService) {
         var vm = this;
-        vm.announcement = angular.copy(announcement);
-        vm.action = action;
 
-        vm.save = save;
         vm.cancel = cancel;
         vm.create = create;
-        vm.deleteAnnouncement = deleteAnnouncement;
         vm.datesInvalid = datesInvalid;
+        vm.deleteAnnouncement = deleteAnnouncement;
+        vm.save = save;
 
         activate();
 
         ////////////////////////////////////////////////////////////////////
 
         function activate () {
+            vm.announcement = angular.copy(announcement);
+            vm.action = action;
             vm.isChplAdmin = authService.isChplAdmin();
             vm.announcement.startDate = new Date(announcement.startDate);
             vm.announcement.endDate = new Date(announcement.endDate);
-        }
-
-        function datesInvalid () {
-            if (vm.announcement.endDate && vm.announcement.startDate) {
-                return (vm.announcement.endDate < vm.announcement.startDate) }
-            else {
-                return false;
-            }
-        }
-
-        function save () {
-            commonService.modifyAnnouncement(vm.announcement)
-                .then(function (response) {
-                    if (!response.status || response.status === 200) {
-                        $uibModalInstance.close(response);
-                    } else {
-                        $uibModalInstance.dismiss('An error occurred');
-                    }
-                },function (error) {
-                    $uibModalInstance.dismiss(error.data.error);
-                });
         }
 
         function cancel () {
@@ -64,6 +43,14 @@
                 });
         }
 
+        function datesInvalid () {
+            if (vm.announcement.endDate && vm.announcement.startDate) {
+                return (vm.announcement.endDate < vm.announcement.startDate) }
+            else {
+                return false;
+            }
+        }
+
         function deleteAnnouncement () {
             commonService.deleteAnnouncement(vm.announcement.id)
                 .then(function (response) {
@@ -77,5 +64,17 @@
                 });
         }
 
+        function save () {
+            commonService.modifyAnnouncement(vm.announcement)
+                .then(function (response) {
+                    if (!response.status || response.status === 200) {
+                        $uibModalInstance.close(response);
+                    } else {
+                        $uibModalInstance.dismiss('An error occurred');
+                    }
+                },function (error) {
+                    $uibModalInstance.dismiss(error.data.error);
+                });
+        }
     }
 })();

--- a/src/app/admin/components/announcements/edit.controller.spec.js
+++ b/src/app/admin/components/announcements/edit.controller.spec.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    describe('admin.announcements.edit.controller', function () {
+    describe('the Announcement Edit controller', function () {
         var $log, $q, Mock, authService, commonService, mock, scope, vm;
 
         mock = {};
@@ -39,8 +39,6 @@
                 vm = $controller('AnnouncementEditController', {
                     announcement: mock.announcement,
                     action: 'edit',
-                    authService: authService,
-                    commonService: commonService,
                     $uibModalInstance: Mock.modalInstance,
                     $scope: scope,
                 });
@@ -54,22 +52,20 @@
             }
         });
 
-        describe('housekeeping', function () {
-            it('should exist', function () {
-                expect(vm).toBeDefined();
-            });
+        it('should exist', function () {
+            expect(vm).toBeDefined();
+        });
 
-            it('should have some starting values', function () {
-                expect(vm.isChplAdmin).toBe(true);
-                expect(vm.announcement.startDate).toEqual(new Date(mock.announcement.startDate));
-                expect(vm.announcement.endDate).toEqual(new Date(mock.announcement.endDate));
-            });
+        it('should have some starting values', function () {
+            expect(vm.isChplAdmin).toBe(true);
+            expect(vm.announcement.startDate).toEqual(new Date(mock.announcement.startDate));
+            expect(vm.announcement.endDate).toEqual(new Date(mock.announcement.endDate));
+        });
 
-            it('should have a way to close the modal', function () {
-                expect(vm.cancel).toBeDefined();
-                vm.cancel();
-                expect(Mock.modalInstance.dismiss).toHaveBeenCalled();
-            });
+        it('should have a way to close it\'s own modal', function () {
+            expect(vm.cancel).toBeDefined();
+            vm.cancel();
+            expect(Mock.modalInstance.dismiss).toHaveBeenCalled();
         });
 
         it('should know if the dates are invalid', function () {
@@ -84,7 +80,7 @@
             expect(vm.datesInvalid()).toBe(false); // can't check if only have one date
         });
 
-        describe('modifying announcements', function () {
+        describe('when modifying announcements', function () {
             it('should call the common service', function () {
                 vm.save();
                 scope.$digest();
@@ -112,7 +108,7 @@
             });
         });
 
-        describe('creating announcements', function () {
+        describe('when creating announcements', function () {
             it('should call the common service', function () {
                 vm.create();
                 scope.$digest();
@@ -140,7 +136,7 @@
             });
         });
 
-        describe('deleting announcements', function () {
+        describe('when deleting announcements', function () {
             it('should call the common service', function () {
                 vm.deleteAnnouncement();
                 scope.$digest();

--- a/src/app/admin/components/announcements/edit.html
+++ b/src/app/admin/components/announcements/edit.html
@@ -1,7 +1,7 @@
 <div role="modal" aria-labeled-by="editLabel">
   <div class="modal-header">
-    <button type="button" class="close pull-right" aria-label="Cancel edits"
-            confirm="Are you sure you wish to cancel editing? Your changes will not be saved."
+    <button type="button" class="close pull-right" aria-label="Cancel"
+            confirm="Are you sure you wish to cancel? Your changes will not be saved."
             confirm-ok="Yes"
             confirm-cancel="No"
             confirm-settings="{animation: false, keyboard: false, backdrop: 'static'}"
@@ -63,24 +63,22 @@
             ng-mouseover="vm.showFormErrors = true"
             ng-if="vm.action === 'create'"
             ng-click="vm.create()"><i class="fa fa-save"></i> Create announcement</button>
-    <span ng-if="!vm.announcement.isDeleted">
-      <button ng-disabled="(vm.editForm.$invalid || vm.datesInvalid()) && vm.showFormErrors" class="btn btn-ai-success btn-block"
-              ng-mouseover="vm.showFormErrors = true"
-              ng-if="vm.action === 'edit'"
-              ng-click="vm.save()"><i class="fa fa-save"></i> Save announcement</button>
-      <button class="btn btn-warning btn-block"
-              confirm="Are you sure you wish to cancel editing? Your changes will not be saved."
-              confirm-ok="Yes"
-              confirm-cancel="No"
-              confirm-settings="{animation: false, keyboard: false, backdrop: 'static'}"
-              ng-click="vm.cancel()"><i class="fa fa-ban"></i> Cancel</button>
-      <button class="btn btn-danger btn-block"
-              ng-if="vm.action === 'edit' && vm.isChplAdmin && !vm.announcement.isDeleted"
-              confirm="Are you sure you wish to delete this announcement?"
-              confirm-ok="Yes"
-              confirm-cancel="No"
-              confirm-settings="{animation: false, keyboard: false, backdrop: 'static'}"
-              ng-click="vm.deleteAnnouncement()"><i class="fa fa-trash-o"></i> Delete announcement</button>
-    </span>
+    <button ng-disabled="(vm.editForm.$invalid || vm.datesInvalid()) && vm.showFormErrors" class="btn btn-ai-success btn-block"
+            ng-mouseover="vm.showFormErrors = true"
+            ng-if="vm.action === 'edit'"
+            ng-click="vm.save()"><i class="fa fa-save"></i> Save announcement</button>
+    <button class="btn btn-danger btn-block"
+            ng-if="vm.action === 'edit' && vm.isChplAdmin && !vm.announcement.isDeleted"
+            confirm="Are you sure you wish to delete this announcement?"
+            confirm-ok="Yes"
+            confirm-cancel="No"
+            confirm-settings="{animation: false, keyboard: false, backdrop: 'static'}"
+            ng-click="vm.deleteAnnouncement()"><i class="fa fa-trash-o"></i> Delete announcement</button>
+    <button class="btn btn-warning btn-block"
+            confirm="Are you sure you wish to cancel editing? Your changes will not be saved."
+            confirm-ok="Yes"
+            confirm-cancel="No"
+            confirm-settings="{animation: false, keyboard: false, backdrop: 'static'}"
+            ng-click="vm.cancel()"><i class="fa fa-ban"></i> Cancel</button>
   </div>
 </div>

--- a/src/app/admin/components/announcements/view.directive.spec.js
+++ b/src/app/admin/components/announcements/view.directive.spec.js
@@ -1,0 +1,186 @@
+(function () {
+    'use strict';
+
+    describe('the Announcement Management View', function () {
+        var $compile, $log, $q, $uibModal, Mock, actualOptions, commonService, el, scope, vm;
+
+        beforeEach(function () {
+            module('chpl.templates', 'chpl.admin', 'chpl.mock', function ($provide) {
+                $provide.decorator('commonService', function ($delegate) {
+                    $delegate.getAnnouncements = jasmine.createSpy('getAnnouncements');
+                    return $delegate;
+                });
+            });
+
+            inject(function (_$compile_, _$log_, _$q_, $rootScope, _$uibModal_, _Mock_, _commonService_) {
+                $compile = _$compile_;
+                $log = _$log_;
+                $q = _$q_;
+                Mock = _Mock_;
+                $uibModal = _$uibModal_;
+                spyOn($uibModal, 'open').and.callFake(function (options) {
+                    actualOptions = options;
+                    return Mock.fakeModal;
+                });
+                commonService = _commonService_;
+                commonService.getAnnouncements.and.returnValue($q.when({}));
+
+                el = angular.element('<ai-announcements-management></ai-announcements-management>');
+                scope = $rootScope.$new();
+                $compile(el)(scope);
+                scope.$digest();
+                vm = el.isolateScope().vm;
+            });
+        });
+
+        afterEach(function () {
+            if ($log.debug.logs.length > 0) {
+                /* eslint-disable no-console,angular/log */
+                console.log('Debug:\n' + $log.debug.logs.map(function (o) { return angular.toJson(o); }).join('\n'));
+                /* eslint-enable no-console,angular/log */
+            }
+        });
+
+        describe('directive', function () {
+            it('should be compiled', function () {
+                expect(el.html()).not.toEqual(null);
+            });
+        });
+
+        describe('controller', function () {
+            it('should have isolate scope object with instanciate members', function () {
+                expect(vm).toEqual(jasmine.any(Object));
+            });
+
+            it('should load announcements on activation', function () {
+                expect(commonService.getAnnouncements).toHaveBeenCalled();
+            });
+
+            it('should log an error on announcement load', function () {
+                var logCount = $log.info.logs.length;
+                commonService.getAnnouncements.and.returnValue($q.reject({}));
+                vm.loadAnnouncements();
+                scope.$digest();
+                expect($log.info.logs.length).toBe(logCount + 1);
+            });
+
+            describe('when creating an announcement', function () {
+                var modalOptions;
+                beforeEach(function () {
+                    modalOptions = {
+                        templateUrl: 'app/admin/components/announcements/edit.html',
+                        controller: 'AnnouncementEditController',
+                        controllerAs: 'vm',
+                        animation: false,
+                        backdrop: 'static',
+                        keyboard: false,
+                        resolve: {
+                            action: jasmine.any(Function),
+                            announcement: jasmine.any(Function),
+                        },
+                    };
+                });
+
+                it('should create a modal instance', function () {
+                    expect(vm.modalInstance).toBeUndefined();
+                    vm.create();
+                    expect(vm.modalInstance).toBeDefined();
+                });
+
+                it('should resolve elements', function () {
+                    vm.create();
+                    expect($uibModal.open).toHaveBeenCalledWith(modalOptions);
+                    expect(actualOptions.resolve.action()).toEqual('create');
+                    expect(actualOptions.resolve.announcement()).toEqual({});
+                });
+
+                it('should create an announcement array if required', function () {
+                    vm.create();
+                    vm.modalInstance.close({name: 'new'});
+                    expect(vm.announcements).toEqual([{name: 'new'}]);
+                });
+
+                it('should push the reponse into the announcement array', function () {
+                    vm.announcements = [];
+                    vm.create();
+                    vm.modalInstance.close({name: 'new'});
+                    expect(vm.announcements).toEqual([{name: 'new'}]);
+                });
+
+                it('should log a non-cancelled modal', function () {
+                    var logCount = $log.info.logs.length;
+                    vm.create();
+                    vm.modalInstance.dismiss('not cancelled');
+                    expect($log.info.logs.length).toBe(logCount + 1);
+                    expect(vm.errorMessage).toBe('not cancelled');
+                });
+
+                it('should not log a cancelled modal', function () {
+                    var logCount = $log.info.logs.length;
+                    vm.create();
+                    vm.modalInstance.dismiss('cancelled');
+                    expect($log.info.logs.length).toBe(logCount);
+                });
+            });
+
+            describe('when editing an announcement', function () {
+                var modalOptions;
+                beforeEach(function () {
+                    modalOptions = {
+                        templateUrl: 'app/admin/components/announcements/edit.html',
+                        controller: 'AnnouncementEditController',
+                        controllerAs: 'vm',
+                        animation: false,
+                        backdrop: 'static',
+                        keyboard: false,
+                        resolve: {
+                            action: jasmine.any(Function),
+                            announcement: jasmine.any(Function),
+                        },
+                    };
+                    vm.announcements = [{id: 1}, {id: 2}];
+                });
+
+                it('should create a modal instance', function () {
+                    expect(vm.modalInstance).toBeUndefined();
+                    vm.edit(vm.announcements[1], 1);
+                    expect(vm.modalInstance).toBeDefined();
+                });
+
+                it('should resolve elements', function () {
+                    vm.edit(vm.announcements[1], 1);
+                    expect($uibModal.open).toHaveBeenCalledWith(modalOptions);
+                    expect(actualOptions.resolve.action()).toEqual('edit');
+                    expect(actualOptions.resolve.announcement()).toEqual(vm.announcements[1]);
+                });
+
+                it('should replace the original with the response', function () {
+                    vm.edit(vm.announcements[1], 1);
+                    vm.modalInstance.close({name: 'new'});
+                    expect(vm.announcements[1]).toEqual({name: 'new'});
+                });
+
+                it('should remove the announcement if deleted', function () {
+                    vm.edit(vm.announcements[1], 1);
+                    vm.modalInstance.close('deleted');
+                    expect(vm.announcements[1]).toBeUndefined();
+                });
+
+                it('should log a non-cancelled modal', function () {
+                    var logCount = $log.info.logs.length;
+                    vm.edit(vm.announcements[1], 1);
+                    vm.modalInstance.dismiss('not cancelled');
+                    expect($log.info.logs.length).toBe(logCount + 1);
+                    expect(vm.errorMessage).toBe('not cancelled');
+                });
+
+                it('should not log a cancelled modal', function () {
+                    var logCount = $log.info.logs.length;
+                    vm.edit(vm.announcements[1], 1);
+                    vm.modalInstance.dismiss('cancelled');
+                    expect($log.info.logs.length).toBe(logCount);
+                });
+            });
+        });
+    });
+})();

--- a/src/app/admin/components/announcements/view.html
+++ b/src/app/admin/components/announcements/view.html
@@ -26,8 +26,8 @@
 		  <td>{{ announcement.text }}</td>
 		  <td>{{ announcement.startDate | date : 'MM/dd/yyyy' : 'UTC'}}</td>
 		  <td>{{ announcement.endDate | date : 'MM/dd/yyyy' : 'UTC'}}</td>
-		  <td><span ng-if="announcement.isPublic">Yes</span><span ng-if="!announcement.isPublic">No</span></td>
-		  <td><button class="btn btn-default btn-block" ng-click="vm.edit(announcement,$index,true)">Edit</button></td>
+		  <td>{{ announcement.isPublic ? 'Yes' : 'No' }}</td>
+		  <td><button class="btn btn-default btn-block" ng-click="vm.edit(announcement,$index)">Edit</button></td>
 		</tr>
 	  </tbody>
 	</table>

--- a/src/app/admin/components/certifiedProduct/listing/edit.controller.js
+++ b/src/app/admin/components/certifiedProduct/listing/edit.controller.js
@@ -108,7 +108,7 @@
             for (var i = 0; i < vm.cp.ics.parents.length; i++) {
                 value = parseInt(vm.cp.ics.parents[i].chplProductNumber.split('.')[6]);
                 code = Math.max(code, value);
-                $log.debug(value, code);
+                $log.debug(vm.cp.ics.parents[i].chplProductNumber.split('.')[6], value, code);
             }
             code = code + 1;
             return (code > 9 || code < 0) ? '' + code : '0' + code;

--- a/src/app/admin/components/certifiedProduct/listing/edit.controller.js
+++ b/src/app/admin/components/certifiedProduct/listing/edit.controller.js
@@ -104,11 +104,8 @@
 
         function requiredIcsCode () {
             var code = -1;
-            var value;
             for (var i = 0; i < vm.cp.ics.parents.length; i++) {
-                value = parseInt(vm.cp.ics.parents[i].chplProductNumber.split('.')[6]);
-                code = Math.max(code, value);
-                $log.debug(vm.cp.ics.parents[i].chplProductNumber.split('.')[6], value, code);
+                code = Math.max(code, parseInt(vm.cp.ics.parents[i].chplProductNumber.split('.')[6], 10));
             }
             code = code + 1;
             return (code > 9 || code < 0) ? '' + code : '0' + code;

--- a/src/app/admin/components/certifiedProduct/listing/edit.controller.js
+++ b/src/app/admin/components/certifiedProduct/listing/edit.controller.js
@@ -104,9 +104,13 @@
 
         function requiredIcsCode () {
             var code = -1;
+            var value;
             for (var i = 0; i < vm.cp.ics.parents.length; i++) {
-                code = Math.max(code, parseInt(vm.cp.ics.parents[i].chplProductNumber.split('.')[6]) + 1);
+                value = parseInt(vm.cp.ics.parents[i].chplProductNumber.split('.')[6]);
+                code = Math.max(code, value);
+                $log.debug(value, code);
             }
+            code = code + 1;
             return (code > 9 || code < 0) ? '' + code : '0' + code;
         }
 

--- a/src/app/admin/components/certifiedProduct/listing/edit.controller.spec.js
+++ b/src/app/admin/components/certifiedProduct/listing/edit.controller.spec.js
@@ -162,9 +162,9 @@
             });
 
             describe('with respect to ics code calculations', function () {
-                it('should expect the code to be -1 if no parents', function () {
+                it('should expect the code to be 00 if no parents', function () {
                     vm.cp.ics.parents = [];
-                    expect(vm.requiredIcsCode()).toBe('-1');
+                    expect(vm.requiredIcsCode()).toBe('00');
                 });
 
                 it('should expect the code to be 1 if one parent and parent has ICS 00', function () {

--- a/src/app/admin/components/certifiedProduct/listing/edit.controller.spec.js
+++ b/src/app/admin/components/certifiedProduct/listing/edit.controller.spec.js
@@ -196,9 +196,9 @@
                     expect(vm.requiredIcsCode()).toBe('03');
                 });
 
-                it('should expect the code to be 10 if two parents and parents have ICS 01,09', function () {
+                it('should expect the code to be 10 if two parents and parents have ICS 04,09', function () {
                     vm.cp.ics.parents = [
-                        {chplProductNumber: '15.07.07.2713.CQ01.02.01.1.170331'},
+                        {chplProductNumber: '15.07.07.2713.CQ01.02.04.1.170331'},
                         {chplProductNumber: '15.07.07.2713.CQ01.02.09.1.170331'},
                     ];
                     expect(vm.requiredIcsCode()).toBe('10');

--- a/src/app/admin/components/certifiedProduct/listing/edit.controller.spec.js
+++ b/src/app/admin/components/certifiedProduct/listing/edit.controller.spec.js
@@ -196,12 +196,20 @@
                     expect(vm.requiredIcsCode()).toBe('03');
                 });
 
-                it('should expect the code to be 10 if two parents and parents have ICS 04,09', function () {
+                it('should expect the code to be 10 if two parents and parents have ICS 03,09', function () {
                     vm.cp.ics.parents = [
                         {chplProductNumber: '15.07.07.2713.CQ01.02.09.1.170331'},
-                        {chplProductNumber: '15.07.07.2713.CQ01.02.04.1.170331'},
+                        {chplProductNumber: '15.07.07.2713.CQ01.02.03.1.170331'},
                     ];
                     expect(vm.requiredIcsCode()).toBe('10');
+                });
+
+                it('should expect the code to be 18 if two parents and parents have ICS 17,11', function () {
+                    vm.cp.ics.parents = [
+                        {chplProductNumber: '15.07.07.2713.CQ01.02.17.1.170331'},
+                        {chplProductNumber: '15.07.07.2713.CQ01.02.11.1.170331'},
+                    ];
+                    expect(vm.requiredIcsCode()).toBe('18');
                 });
             });
         });

--- a/src/app/admin/components/certifiedProduct/listing/edit.controller.spec.js
+++ b/src/app/admin/components/certifiedProduct/listing/edit.controller.spec.js
@@ -198,8 +198,8 @@
 
                 it('should expect the code to be 10 if two parents and parents have ICS 04,09', function () {
                     vm.cp.ics.parents = [
-                        {chplProductNumber: '15.07.07.2713.CQ01.02.04.1.170331'},
                         {chplProductNumber: '15.07.07.2713.CQ01.02.09.1.170331'},
+                        {chplProductNumber: '15.07.07.2713.CQ01.02.04.1.170331'},
                     ];
                     expect(vm.requiredIcsCode()).toBe('10');
                 });


### PR DESCRIPTION
Also some code coverage things.

The weird Jenkins failures were because javascript's parseint treats "09" as a hexadecimal number, and parses that to be 0. Making parseint run as `parseint("09",10)` forces it to treat "09" as decimal