### PR TITLE
OCD-1941: Add unique ids to login form elements

### DIFF
--- a/src/app/admin/components/login/login.html
+++ b/src/app/admin/components/login/login.html
@@ -1,25 +1,25 @@
 <div>
   <form name="vm.loginForm" class="form-horizontal" ng-class="vm.formClass" role="log in / log out">
     <div class="form-group" ng-if="vm.activity !== vm.activityEnum.NONE && vm.activity !== vm.activityEnum.CHANGE">
-      <label class="control-label col-sm-4" for="username">Username <span class="text-danger">*</span></label>
+      <label class="control-label col-sm-4" for="username_{{$id}}">Username <span class="text-danger">*</span></label>
       <div class="col-sm-8">
-        <input type="text" class="form-control" id="username" name="username" ng-model="vm.userName" placeholder="username" required />
+        <input type="text" class="form-control" id="username_{{$id}}" name="username" ng-model="vm.userName" placeholder="username" required />
         <div class="text-danger" ng-if="vm.loginForm.username.$touched && vm.loginForm.username.$error.required">Username is required</div>
       </div>
     </div>
 
     <div class="form-group" ng-if="vm.activity === vm.activityEnum.LOGIN || vm.activity === vm.activityEnum.CHANGE">
-      <label class="control-label col-sm-4" for="password"><span ng-if="vm.activity === vm.activityEnum.CHANGE">Old </span>Password <span class="text-danger">*</span></label>
+      <label class="control-label col-sm-4" for="password_{{$id}}"><span ng-if="vm.activity === vm.activityEnum.CHANGE">Old </span>Password <span class="text-danger">*</span></label>
       <div class="col-sm-8">
-        <input type="password" class="form-control" id="password" name="password" ng-model="vm.password" placeholder="password" required />
+        <input type="password" class="form-control" id="password_{{$id}}" name="password" ng-model="vm.password" placeholder="password" required />
         <div class="text-danger" ng-if="vm.loginForm.password.$touched && vm.loginForm.password.$error.required">Password is required</div>
       </div>
     </div>
 
     <div class="form-group" ng-if="vm.activity === vm.activityEnum.LOGIN || vm.activity === vm.activityEnum.CHANGE">
-      <label class="control-label col-sm-4" for="newPassword" ng-if="vm.activity === vm.activityEnum.CHANGE">New Password <span class="text-danger">*</span></label>
+      <label class="control-label col-sm-4" for="newPassword_{{$id}}" ng-if="vm.activity === vm.activityEnum.CHANGE">New Password <span class="text-danger">*</span></label>
       <div class="col-sm-8">
-        <input type="password" class="form-control" id="newPassword" name="newPassword" ng-model="vm.newPassword" placeholder="new password" ng-pattern="vm.pwPattern" required ng-if="vm.activity === vm.activityEnum.CHANGE"/>
+        <input type="password" class="form-control" id="newPassword_{{$id}}" name="newPassword" ng-model="vm.newPassword" placeholder="new password" ng-pattern="vm.pwPattern" required ng-if="vm.activity === vm.activityEnum.CHANGE"/>
         <div class="text-danger" ng-if="vm.loginForm.newPassword.$touched && vm.loginForm.newPassword.$error.pattern">Password must
           <ul>
             <li>Contain at least one upper case letter</li>
@@ -33,18 +33,18 @@
     </div>
 
     <div class="form-group" ng-if="vm.activity === vm.activityEnum.CHANGE">
-      <label class="control-label col-sm-4" for="confirmPassword">Confirm Password <span class="text-danger">*</span></label>
+      <label class="control-label col-sm-4" for="confirmPassword_{{$id}}">Confirm Password <span class="text-danger">*</span></label>
       <div class="col-sm-8">
-        <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" ng-model="vm.confirmPassword" placeholder="confirm password" required />
+        <input type="password" class="form-control" id="confirmPassword_{{$id}}" name="confirmPassword" ng-model="vm.confirmPassword" placeholder="confirm password" required />
         <div class="text-danger" ng-if="vm.loginForm.confirmPassword.$touched && vm.loginForm.confirmPassword.$error.required">Confirm password is required</div>
         <div class="text-danger" ng-if="vm.loginForm.confirmPassword.$touched && vm.misMatchPasswords()">Passwords must match</div>
       </div>
     </div>
 
     <div class="form-group" ng-if="vm.activity === vm.activityEnum.RESET">
-      <label class="control-label col-sm-4" for="email">Email <span class="text-danger">*</span></label>
+      <label class="control-label col-sm-4" for="email_{{$id}}">Email <span class="text-danger">*</span></label>
       <div class="col-sm-8">
-        <input type="email" class="form-control" id="email" name="email" ng-model="vm.email" placeholder="sample@example.com" required />
+        <input type="email" class="form-control" id="email_{{$id}}" name="email" ng-model="vm.email" placeholder="sample@example.com" required />
         <div class="text-danger" ng-if="vm.loginForm.email.$touched && vm.loginForm.email.$error.required">Email is required</div>
         <div class="text-danger" ng-if="vm.loginForm.email.$touched && vm.loginForm.email.$error.email">Invalid email</div>
       </div>


### PR DESCRIPTION
@ashwinimore this might help with your troubles trying to log in. The IDs for the username / password fields will now be something like `id=username_32` and `id=password_32` for the one on the nav bar, and `username_393 password_393` for the one in the "central" area of the admin section. That gets rid of some of the console errors that shows up otherwise