### PR TITLE
fix: restrict modifications when Developer is not Active

### DIFF
--- a/src/app/pages/listing/listing.component.js
+++ b/src/app/pages/listing/listing.component.js
@@ -17,10 +17,9 @@ export const ListingComponent = {
         }
 
         $onInit () {
-            this.$log.info(this);
             this.loading = true;
-            this.productId = this.$stateParams.id; //this.id; //this.resolve.id; ?
-            this.initialPanel = this.$stateParams.initialPanel || 'cert'; //this.resolve.initialPanel || 'cert';
+            this.productId = this.$stateParams.id;
+            this.initialPanel = this.$stateParams.initialPanel || 'cert';
             if (this.$localStorage.previouslyViewed) {
                 this.previouslyViewed = this.$localStorage.previouslyViewed;
 
@@ -36,6 +35,12 @@ export const ListingComponent = {
             }
 
             this.loadProduct();
+        }
+
+        can (action) {
+            if (this.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC'])) { return true; } // can do everything
+            if (action === 'merge') { return false; } // if not above roles, can't merge
+            return this.product.developer.status.status === 'Active' && this.hasAnyRole(['ROLE_ACB']); // must be active
         }
 
         loadProduct () {

--- a/src/app/pages/listing/listing.html
+++ b/src/app/pages/listing/listing.html
@@ -33,9 +33,9 @@
         <div class="col-sm-4" id="product-information-basic">
           <div class="product-element" id="product-information-developer">
             <chpl-developer developer="$ctrl.product.developer"
-                            can-edit="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC', 'ROLE_ACB'])"
-                            can-merge="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC'])"
-                            can-split="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC', 'ROLE_ACB'])"
+                            can-edit="$ctrl.can('edit')"
+                            can-merge="$ctrl.can('merge')"
+                            can-split="$ctrl.can('split')"
                             take-action="$ctrl.takeDeveloperAction(action, developerId)"
                             ></chpl-developer>
           </div>

--- a/src/app/pages/organizations/developers/developers.component.js
+++ b/src/app/pages/organizations/developers/developers.component.js
@@ -40,6 +40,13 @@ export const DevelopersComponent = {
             }
         }
 
+        can (action) {
+            if (action === 'split-developer' && this.products.length < 2) { return false; } // cannot split developer without at least two products
+            if (this.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC'])) { return true; } // can do everything
+            if (action === 'merge') { return false; } // if not above roles, can't merge
+            return this.developer.status.status === 'Active' && this.hasAnyRole(['ROLE_ACB']); // must be active
+        }
+
         cancel () {
             this.developer = angular.copy(this.backup.developer);
             this.newDeveloper = angular.copy(this.developer);

--- a/src/app/pages/organizations/developers/developers.html
+++ b/src/app/pages/organizations/developers/developers.html
@@ -12,7 +12,7 @@
   </div>
   <div class="row main-content" id="main-content" tabindex="-1" ng-if="!$ctrl.$stateParams.productId">
     <div class="col-md-6">
-      <ul ng-if="$ctrl.errorMesssages && $ctrl.errorMessages.length > 0" class="bg-danger">
+      <ul ng-if="$ctrl.errorMessages && $ctrl.errorMessages.length > 0" class="bg-danger">
         <li ng-repeat="msg in $ctrl.errorMessages">{{ msg }}</li>
       </ul>
       <h2 ng-if="$ctrl.action === 'split'">Original Developer</h2>

--- a/src/app/pages/organizations/developers/developers.html
+++ b/src/app/pages/organizations/developers/developers.html
@@ -18,9 +18,9 @@
       <h2 ng-if="$ctrl.action === 'split'">Original Developer</h2>
       <chpl-developer allowed-acbs="$ctrl.allowedAcbs"
                       developer="$ctrl.developer"
-                      can-edit="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC', 'ROLE_ACB'])"
-                      can-merge="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC'])"
-                      can-split="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC', 'ROLE_ACB'])"
+                      can-edit="$ctrl.can('edit')"
+                      can-merge="$ctrl.can('merge')"
+                      can-split="$ctrl.can('split-developer')"
                       is-editing="$ctrl.action === 'edit' || $ctrl.action === 'merge'"
                       is-invalid="$ctrl.action === 'merge' && $ctrl.mergingDevelopers.length === 0"
                       on-cancel="$ctrl.cancel()"
@@ -42,9 +42,9 @@
       <h2>Products</h2>
       <div ng-repeat="product in $ctrl.products | orderBy: 'name'">
         <chpl-product product="product"
-                      can-edit="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC', 'ROLE_ACB'])"
-                      can-merge="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC'])"
-                      can-split="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC', 'ROLE_ACB'])"
+                      can-edit="$ctrl.can('edit')"
+                      can-merge="$ctrl.can('merge')"
+                      can-split="$ctrl.can('split-product')"
                       take-action="$ctrl.takeProductAction(action, productId)"
                       ></chpl-product>
       </div>
@@ -67,7 +67,7 @@
     <div class="col-md-6" ng-if="$ctrl.action === 'split'">
       <h2>New Developer</h2>
       <chpl-developer developer="$ctrl.newDeveloper"
-                      can-edit="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC', 'ROLE_ACB'])"
+                      can-edit="$ctrl.can('edit')"
                       is-editing="$ctrl.splitEdit"
                       is-splitting="true"
                       on-cancel="$ctrl.cancelSplitEdit()"

--- a/src/app/pages/organizations/developers/products/products.component.js
+++ b/src/app/pages/organizations/developers/products/products.component.js
@@ -44,6 +44,13 @@ export const ProductsComponent = {
             }
         }
 
+        can (action) {
+            if (action === 'split-product' && this.versions.length < 2) { return false; } // cannot split product without at least two versions
+            if (this.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC'])) { return true; } // can do everything
+            if (action === 'merge') { return false; } // if not above roles, can't merge
+            return this.developer.status.status === 'Active' && this.hasAnyRole(['ROLE_ACB']); // must be active
+        }
+
         cancel () {
             this.product = angular.copy(this.backup.product);
             this.newProduct = angular.copy(this.product);

--- a/src/app/pages/organizations/developers/products/products.html
+++ b/src/app/pages/organizations/developers/products/products.html
@@ -23,9 +23,9 @@
       <h2 ng-if="$ctrl.action === 'split'">Original Product</h2>
       <chpl-product product="$ctrl.product"
                     developers="$ctrl.developers"
-                    can-edit="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC', 'ROLE_ACB'])"
-                    can-merge="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC'])"
-                    can-split="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC', 'ROLE_ACB'])"
+                    can-edit="$ctrl.can('edit')"
+                    can-merge="$ctrl.can('merge')"
+                    can-split="$ctrl.can('split-product')"
                     is-editing="$ctrl.action === 'edit' || $ctrl.action === 'merge'"
                     is-invalid="$ctrl.action === 'merge' && $ctrl.mergingProducts.length === 0"
                     on-cancel="$ctrl.cancel()"
@@ -76,7 +76,7 @@
       <h2>New Product</h2>
       <chpl-product product="$ctrl.newProduct"
                     developers="$ctrl.developers"
-                    can-edit="$ctrl.hasAnyRole(['ROLE_ADMIN', 'ROLE_ONC', 'ROLE_ACB'])"
+                    can-edit="$ctrl.can('edit')"
                     is-editing="$ctrl.splitEdit"
                     is-splitting="true"
                     on-cancel="$ctrl.cancelSplitEdit()"

--- a/src/app/pages/organizations/developers/products/products.html
+++ b/src/app/pages/organizations/developers/products/products.html
@@ -17,7 +17,7 @@
                       ></chpl-developer>
     </div>
     <div class="col-md-5">
-      <ul ng-if="$ctrl.errorMesssages && $ctrl.errorMessages.length > 0" class="bg-danger">
+      <ul ng-if="$ctrl.errorMessages && $ctrl.errorMessages.length > 0" class="bg-danger">
         <li ng-repeat="msg in $ctrl.errorMessages">{{ msg }}</li>
       </ul>
       <h2 ng-if="$ctrl.action === 'split'">Original Product</h2>


### PR DESCRIPTION
ROLE_ACB cannot edit Developers, Products, or Versions when the status
of the Developer is not "Active". This commit enforces that for
Developers and Products; Versions are still to come

[#OCD-2757]