### PR TITLE
[#OCD-3539] fix!: Display correct chart data for logged in users

### DIFF
--- a/src/app/pages/charts/charts.module.js
+++ b/src/app/pages/charts/charts.module.js
@@ -2,6 +2,5 @@ export default angular
     .module('chpl.charts', [
         'chpl.services',
         'googlechart',
-        'feature-flags',
         'ui.bootstrap',
     ]);

--- a/src/app/pages/charts/developer/developer.component.js
+++ b/src/app/pages/charts/developer/developer.component.js
@@ -5,10 +5,9 @@ export const ChartsDeveloperComponent = {
         listingCountData: '<',
     },
     controller: class ChartsDeveloperComponent {
-        constructor ($log, featureFlags) {
+        constructor ($log) {
             'ngInject';
             this.$log = $log;
-            this.isOn = featureFlags.isOn;
             this.chartState = {
                 isStacked: 'false',
             };
@@ -121,12 +120,8 @@ export const ChartsDeveloperComponent = {
             return {
                 type: 'ColumnChart',
                 data: {
-                    cols: this.isOn('effective-rule-date-plus-three-months') ? [
+                    cols: [
                         { label: 'Number of Developers and Products with "' + status + '" Listings', type: 'string'},
-                        { label: 'Certification Edition 2015', type: 'number'},
-                    ] : [
-                        { label: 'Number of Developers and Products with "' + status + '" Listings', type: 'string'},
-                        { label: 'Certification Edition 2014', type: 'number'},
                         { label: 'Certification Edition 2015', type: 'number'},
                     ],
                     rows: this._getListingCountChartClassData(data, status),

--- a/src/app/pages/charts/developer/developer.html
+++ b/src/app/pages/charts/developer/developer.html
@@ -13,15 +13,7 @@
     <p>The 2011 and 2014 editions have been retired and have no "{{ $ctrl.chartState.listingCountType.name }}" listings.</p>
   </div>
 </div>
-<div class="row" feature-flag="effective-rule-date-plus-three-months" feature-flag-hide>
-  <div class="col-sm-6">
-    <div google-chart="" chart="$ctrl.listingCount.edition['' + $ctrl.chartState.listingCountType.id].chart" class="column-chart"></div>
-  </div>
-  <div class="col-sm-6">
-    <div google-chart="" chart="$ctrl.listingCount.class['' + $ctrl.chartState.listingCountType.id].chart" class="column-chart"></div>
-  </div>
-</div>
-<div class="row" feature-flag="effective-rule-date-plus-three-months">
+<div class="row">
   <div class="col-sm-6">
     <div google-chart="" chart="$ctrl.listingCount.edition['' + $ctrl.chartState.listingCountType.id].chart" class="column-chart"></div>
   </div>

--- a/src/app/pages/charts/product/product.component.js
+++ b/src/app/pages/charts/product/product.component.js
@@ -4,18 +4,17 @@ export const ChartsProductComponent = {
         criterionProduct: '<',
     },
     controller: class ChartsProductComponent {
-        constructor ($log, featureFlags, utilService) {
+        constructor ($log, utilService) {
             'ngInject';
             this.$log = $log;
             this.utilService = utilService;
-            this.isOn = featureFlags.isOn;
             this.criteriaTypes = [
                 'All',
                 2015,
                 '2015 Cures Update',
             ];
             this.chartState = {
-                criteriaType: this.isOn('effective-rule-date-plus-three-months') ? 'All' : 2014,
+                criteriaType: 'All',
             };
         }
 

--- a/src/app/pages/charts/product/product.html
+++ b/src/app/pages/charts/product/product.html
@@ -1,9 +1,5 @@
 <div class="row">
   <div class="col-sm-12">
-    <ul class="nav nav-tabs" feature-flag="effective-rule-date-plus-three-months" feature-flag-hide>
-      <li role="presentation" ng-class="{'active': $ctrl.chartState.criteriaType === 2014}"><a ng-click="$ctrl.chartState.criteriaType = 2014">2014 Edition</a></li>
-      <li role="presentation" ng-class="{'active': $ctrl.chartState.criteriaType !== 2014}"><a ng-click="$ctrl.chartState.criteriaType = 'All'">2015 Edition</a></li>
-    </ul>
     <p>The charts below describe the number of unique products that have been certified to each of the ONC certification criteria. A unique product represents a group of CHPL listings that refer to a single product from the same developer, each listing in a group often differing by version number.</p>
     <div google-chart="" chart="$ctrl.criterionProductCounts['' + $ctrl.chartState.criteriaType]" class="bar-chart"></div>
   </div>

--- a/src/app/pages/charts/surveillance/surveillance.component.js
+++ b/src/app/pages/charts/surveillance/surveillance.component.js
@@ -4,27 +4,16 @@ export const ChartsSurveillanceComponent = {
         nonconformityCriteriaCount: '<',
     },
     controller: class ChartsSurveillanceComponent {
-        constructor ($log, featureFlags, utilService) {
+        constructor ($log, utilService) {
             'ngInject';
             this.$log = $log;
             this.utilService = utilService;
-            this.isOn = featureFlags.isOn;
-            if (this.isOn('effective-rule-date-plus-three-months')) {
-                this.nonconformityTypes = [
-                    'All',
-                    2015,
-                    '2015 Cures Update',
-                    'Program',
-                ];
-            } else {
-                this.nonconformityTypes = [
-                    'All',
-                    2014,
-                    2015,
-                    '2015 Cures Update',
-                    'Program',
-                ];
-            }
+            this.nonconformityTypes = [
+                'All',
+                2015,
+                '2015 Cures Update',
+                'Program',
+            ];
             this.chartState = {
                 yAxis: '',
                 nonconformityCountType: 'All',
@@ -196,8 +185,6 @@ export const ChartsSurveillanceComponent = {
                 })
                 .filter(obj => {
                     switch (type) {
-                    case 2014:
-                        return obj.nonconformityType.includes('170.314');
                     case 2015:
                         return (obj.nonconformityType.includes('170.315') && !obj.nonconformityType.includes('Cures Update'));
                     case '2015 Cures Update':
@@ -205,11 +192,9 @@ export const ChartsSurveillanceComponent = {
                     case 'Program':
                         return obj.nonconformityType.includes('170.523') || obj.nonconformityType.includes('Other');
                     case 'All':
-                        if (this.isOn('effective-rule-date-plus-three-months')) {
-                            return !obj.nonconformityType.includes('170.314');
-                        }
-                        return true;
-                        // no default
+                        return !obj.nonconformityType.includes('170.314');
+                    default:
+                        return false;
                     }
                 })
                 .sort((a, b) => this.utilService.sortCertActual(a, b))

--- a/src/app/pages/charts/surveillance/surveillance.component.spec.js
+++ b/src/app/pages/charts/surveillance/surveillance.component.spec.js
@@ -27,7 +27,7 @@
                 {id: null, nonconformityCount: 13, nonconformityType: '170.314 (c)(1)', deleted: false, lastModifiedUser: -2, creationDate: 1531422312250, lastModifiedDate: 1531422312250},
                 {id: null, nonconformityCount: 2, nonconformityType: '170.314 (a)(13)', deleted: false, lastModifiedUser: -2, creationDate: 1531422312250, lastModifiedDate: 1531422312250},
                 {id: null, nonconformityCount: 9, nonconformityType: '170.314 (c)(2)', deleted: false, lastModifiedUser: -2, creationDate: 1531422312250, lastModifiedDate: 1531422312250},
-                {id: null, nonconformityCount: 1, nonconformityType: '170.315 (c)(2)', deleted: false, lastModifiedUser: -2, creationDate: 1531422312250, lastModifiedDate: 1531422312250},
+                {id: null, nonconformityCount: 1, nonconformityType: '170.315 (c)(2) (Cures Update)', deleted: false, lastModifiedUser: -2, creationDate: 1531422312250, lastModifiedDate: 1531422312250},
                 {id: null, nonconformityCount: 63, nonconformityType: 'Other Non-Conformity', deleted: false, lastModifiedUser: -2,creationDate: 1531422312250, lastModifiedDate: 1531422312250},
             ]},
         };
@@ -72,15 +72,15 @@
             });
 
             it('should filter data by nonconformity type', () => {
-                expect(ctrl.nonconformityCounts[2014].data.rows.length).toBe(16);
-                expect(ctrl.nonconformityCounts[2015].data.rows.length).toBe(5);
-                expect(ctrl.nonconformityCounts['All'].data.rows.length).toBe(24);
+                expect(ctrl.nonconformityCounts[2014].data.rows.length).toBe(0);
+                expect(ctrl.nonconformityCounts[2015].data.rows.length).toBe(4);
+                expect(ctrl.nonconformityCounts['2015 Cures Update'].data.rows.length).toBe(1);
+                expect(ctrl.nonconformityCounts['All'].data.rows.length).toBe(8);
                 expect(ctrl.nonconformityCounts['Program'].data.rows.length).toBe(3);
-                expect(ctrl.nonconformityCounts['All'].data.rows.length).toBe(24);
             });
 
             it('should format the data correctly', () => {
-                expect(ctrl.nonconformityCounts['All'].data.rows[0].c[0].v).toBe('170.314 (a)(8)');
+                expect(ctrl.nonconformityCounts['All'].data.rows[0].c[0].v).toBe('170.315 (a)(1)');
             });
         });
     });


### PR DESCRIPTION
Issue was that the /feature-flags data was not available during while
components were being constructed, when user was logged in. Not sure
why, but removing the flag check in the constructor solved the issue.
There was also a workaround that a logged in user could select a
different chart and come back to the Developers chart, and they'd see
the right data

While fixing this issue, I also removed the ERD+3 months flag from
the charts ticket, as required for OCD-3532

[#OCD-3539]