### PR TITLE
OCD-4625: Remove Admin-only Power BI page

### DIFF
--- a/src/app/navigation/navigation-top.html
+++ b/src/app/navigation/navigation-top.html
@@ -90,7 +90,6 @@
               <li ng-if="vm.hasAnyRole(['chpl-admin', 'chpl-onc', 'chpl-onc-acb'])"><a ui-sref="administration.change-requests"><i class="fa fa-caret-right" ng-if="vm.isActive('administration.change-requests')"></i> Change Requests</a></li>
               <li ng-if="vm.hasAnyRole(['chpl-admin', 'chpl-onc'])"><a ui-sref="administration.system-maintenance"><i class="fa fa-caret-right" ng-if="vm.isActive('administration.system-maintenance')"></i> System Maintenance</a></li>
               <li ng-if="vm.hasAnyRole(['chpl-admin'])"><a ui-sref="style-guide"><i class="fa fa-caret-right" ng-if="vm.isActive('sys-admin.style-guide')"></i>Style Guide</a></li>
-              <li ng-if="vm.hasAnyRole(['chpl-admin'])"><a ui-sref="power-bi"><i class="fa fa-caret-right" ng-if="vm.isActive('sys-admin.power-bi')"></i>Power BI Report</a></li>
               <li ng-if="vm.hasAnyRole(['chpl-admin'])"><a href="rest/ff4j-console/home">FF4j</a></li>
             </ul>
           </li>

--- a/src/app/pages/resources/power-bi/index.js
+++ b/src/app/pages/resources/power-bi/index.js
@@ -1,3 +1,0 @@
-import PowerBI from './power-bi';
-
-export default PowerBI;

--- a/src/app/pages/resources/power-bi/power-bi.jsx
+++ b/src/app/pages/resources/power-bi/power-bi.jsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-function PowerBI() {
-  return (
-    <iframe title="CuresUpdate" width="900" height="600" src="https://app.powerbi.com/view?r=eyJrIjoiMjUyNTU3MWQtNjE5YS00NGQzLTkzM2YtZDZkZDcyZmJiOGQ1IiwidCI6IjMwN2QyMTJhLWZiODYtNDgwNy04NGRkLTg2Nzc2OWI4MDQyYSIsImMiOjF9" frameborder="0" allowFullScreen="true" />
-  );
-}
-
-export default PowerBI;

--- a/src/app/pages/resources/resources.module.js
+++ b/src/app/pages/resources/resources.module.js
@@ -6,7 +6,6 @@ import ChplResourcesApi from './api';
 import ChplResourcesDownloadWrapper from './download/download-wrapper';
 import ChplResourcesOverview from './overview';
 import ChplStyleGuide from './style-guide';
-import PowerBI from './power-bi';
 
 angular
   .module('chpl.resources', [
@@ -20,5 +19,4 @@ angular
   .component('chplResourcesApiBridge', reactToAngularComponent(ChplResourcesApi))
   .component('chplResourcesDownloadWrapperBridge', reactToAngularComponent(ChplResourcesDownloadWrapper))
   .component('chplResourcesOverviewBridge', reactToAngularComponent(ChplResourcesOverview))
-  .component('chplStyleGuideBridge', reactToAngularComponent(ChplStyleGuide))
-  .component('powerBIBridge', reactToAngularComponent(PowerBI));
+  .component('chplStyleGuideBridge', reactToAngularComponent(ChplStyleGuide));

--- a/src/app/pages/resources/resources.state.js
+++ b/src/app/pages/resources/resources.state.js
@@ -48,14 +48,6 @@ const states = [
       title: 'CHPL Style Guide',
       roles: ['chpl-admin'],
     },
-  }, {
-    name: 'power-bi',
-    url: '/power-bi',
-    component: 'powerBIBridge',
-    data: {
-      title: 'Power BI Report',
-      roles: ['chpl-admin'],
-    },
   },
 ];
 


### PR DESCRIPTION
This page referenced the cures-update report as a proof of concept for showing Power BI reports in the CHPL. We removed the endpoint and data behind the cures-update report so we are also removing this page.

[#OCD-4625]