### PR TITLE
OCD-4630: Check dev id instead of dev name in product owner history

### DIFF
--- a/src/app/components/products/product/edit.component.js
+++ b/src/app/components/products/product/edit.component.js
@@ -94,7 +94,7 @@ const ProductEditComponent = {
       if (this.product) {
         this.product.ownerHistory.forEach((o, idx, arr) => {
           if (idx > 0) {
-            if (arr[idx].developer.name === arr[idx - 1].developer.name) {
+            if (arr[idx].developer.id === arr[idx - 1].developer.id) {
               messages.push(`Product cannot transfer from Developer "${arr[idx].developer.name}" to the same Developer`);
             }
             if (arr[idx].transferDay === arr[idx - 1].transferDay) {


### PR DESCRIPTION
There are a few examples in the data where a product has an owner history and the previous owner has the same name as the current owner but upon inspection of the data they are actually different developers. See developer ID 369. This seems due to joins and renames of developers over time.