### PR TITLE
OCD-5234 Code Set Indicator

### DIFF
--- a/src/app/components/listing/details/criteria/code-set-indicator/code-set-indicator.jsx
+++ b/src/app/components/listing/details/criteria/code-set-indicator/code-set-indicator.jsx
@@ -1,0 +1,138 @@
+import React, { useContext, useEffect, useState } from 'react';
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  List,
+  ListItem,
+  Typography,
+  makeStyles,
+} from '@material-ui/core';
+import RadioButtonCheckedIcon from '@material-ui/icons/RadioButtonChecked';
+import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
+
+import { useFetchCodeSets } from 'api/standards';
+import { UserContext } from 'shared/contexts';
+import {
+  certificationResult,
+} from 'shared/prop-types';
+import { getDisplayDateFormat, jsJoda } from 'services/date-util';
+import { palette } from 'themes';
+
+const useStyles = makeStyles({
+  upToDate: {
+    backgroundColor: palette.active,
+    color: palette.white,
+    '& .MuiChip-icon': {
+      color: palette.white,
+    },
+  },
+  notUpToDate: {
+    backgroundColor: palette.error,
+    color: palette.white,
+    '& .MuiChip-icon': {
+      color: palette.white,
+    },
+  },
+});
+
+function ChplCodeSetIndicator({ criterion }) {
+  const { hasAnyRole } = useContext(UserContext);
+  const { data, isError, isLoading } = useFetchCodeSets();
+  const [allCodeSets, setAllCodeSets] = useState([]);
+  const [codeSetStatus, setCodeSetStatus] = useState(undefined);
+  const classes = useStyles();
+
+  useEffect(() => {
+    if (isError || isLoading) { return; }
+    setAllCodeSets(data);
+  }, [data, isError, isLoading]);
+
+  useEffect(() => {
+    if (!allCodeSets || !criterion.codeSets) { return; }
+    const today = jsJoda.LocalDate.now(jsJoda.ZoneId.of('America/New_York')).toString();
+    const criterionCodeSetIds = new Set(criterion.codeSets.map((cs) => cs.codeSet.id));
+    const missingRequired = allCodeSets
+      .filter((cs) => cs.criteria?.some((c) => c.id === criterion.criterion.id) && cs.requiredDay)
+      .find((cs) => cs.requiredDay <= today && !criterionCodeSetIds.has(cs.id));
+    if (missingRequired) {
+      setCodeSetStatus({ status: 'notUpToDate', requiredDay: missingRequired.requiredDay });
+    }
+    const latestRequired = allCodeSets
+      .filter((cs) => cs.criteria?.some((c) => c.id === criterion.criterion.id) && cs.requiredDay)
+      .filter((cs) => criterionCodeSetIds.has(cs.id))
+      .sort((a, b) => (a.requiredDay > b.requiredDay ? -1 : 1))[0];
+    setCodeSetStatus({ status: 'upToDate', requiredDay: latestRequired?.requiredDay });
+  }, [allCodeSets, criterion]);
+
+  if (isLoading || isError || !codeSetStatus) { return <CircularProgress />; }
+
+  if (hasAnyRole(['chpl-admin', 'chpl-onc', 'chpl-onc-acb'])) {
+    return (
+      <>
+        { criterion.codeSets.length > 0
+          && (
+            <List>
+              { criterion.codeSets.map((cs) => (
+                <ListItem key={cs.id}>
+                  { cs.codeSet.name }
+                </ListItem>
+              ))}
+            </List>
+          )}
+        { criterion.codeSets?.length === 0 && 'None' }
+      </>
+    );
+  }
+
+  return (
+    <Box display="flex" alignItems="center" gridGap={8}>
+      { codeSetStatus.status === 'upToDate'
+        && (
+          <>
+            <Chip
+              icon={<RadioButtonCheckedIcon />}
+              label="Up-to-date"
+              className={classes.upToDate}
+            />
+            <Typography variant="body2">
+              This criterion meets the current code set requirement.
+              { codeSetStatus.requiredDay && (
+                <>
+                  {' The required date for this code set is '}
+                  { getDisplayDateFormat(codeSetStatus.requiredDay) }
+                  {'.'}
+                </>
+              )}
+            </Typography>
+          </>
+        )}
+      { codeSetStatus.status === 'notUpToDate'
+        && (
+          <>
+            <Chip
+              icon={<RadioButtonUncheckedIcon />}
+              label="Not up-to-date"
+              className={classes.notUpToDate}
+            />
+            <Typography variant="body2">
+              This criterion&apos;s code set does not meet the requirement that took effect as of
+              { codeSetStatus.requiredDay && (
+                <>
+                  {' '}
+                  { getDisplayDateFormat(codeSetStatus.requiredDay) }
+                </>
+              )}
+              . Contact the developer for more information.
+            </Typography>
+          </>
+        )}
+    </Box>
+  );
+}
+
+export default ChplCodeSetIndicator;
+
+ChplCodeSetIndicator.propTypes = {
+  criterion: certificationResult.isRequired,
+};

--- a/src/app/components/listing/details/criteria/code-set-indicator/code-set-indicator.jsx
+++ b/src/app/components/listing/details/criteria/code-set-indicator/code-set-indicator.jsx
@@ -1,71 +1,37 @@
 import React, { useContext, useEffect, useState } from 'react';
 import {
   Box,
-  Chip,
   CircularProgress,
   List,
   ListItem,
   Typography,
-  makeStyles,
 } from '@material-ui/core';
-import RadioButtonCheckedIcon from '@material-ui/icons/RadioButtonChecked';
-import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
 
 import { useFetchCodeSets } from 'api/standards';
+import { ChplUpdateIndicator } from 'components/util';
 import { UserContext } from 'shared/contexts';
-import {
-  certificationResult,
-} from 'shared/prop-types';
-import { getDisplayDateFormat, jsJoda } from 'services/date-util';
-import { palette } from 'themes';
-
-const useStyles = makeStyles({
-  upToDate: {
-    backgroundColor: palette.active,
-    color: palette.white,
-    '& .MuiChip-icon': {
-      color: palette.white,
-    },
-  },
-  notUpToDate: {
-    backgroundColor: palette.error,
-    color: palette.white,
-    '& .MuiChip-icon': {
-      color: palette.white,
-    },
-  },
-});
+import { certificationResult } from 'shared/prop-types';
 
 function ChplCodeSetIndicator({ criterion }) {
   const { hasAnyRole } = useContext(UserContext);
   const { data, isError, isLoading } = useFetchCodeSets();
-  const [allCodeSets, setAllCodeSets] = useState([]);
-  const [codeSetStatus, setCodeSetStatus] = useState(undefined);
-  const classes = useStyles();
+  const [relevantCodeSets, setRelevantCodeSets] = useState([]);
+  const [endDay, setEndDay] = useState(undefined);
 
   useEffect(() => {
     if (isError || isLoading) { return; }
-    setAllCodeSets(data);
+    setRelevantCodeSets(data.filter((cs) => cs.criteria.some((cc) => cc.id === criterion.criterion.id)));
   }, [data, isError, isLoading]);
 
   useEffect(() => {
-    if (!allCodeSets || !criterion.codeSets) { return; }
-    const today = jsJoda.LocalDate.now(jsJoda.ZoneId.of('America/New_York')).toString();
-    const criterionCodeSetIds = new Set(criterion.codeSets.map((cs) => cs.codeSet.id));
-    const missingRequired = allCodeSets
-      .filter((cs) => cs.criteria?.some((c) => c.id === criterion.criterion.id) && cs.requiredDay)
-      .find((cs) => cs.requiredDay <= today && !criterionCodeSetIds.has(cs.id));
-    if (missingRequired) {
-      setCodeSetStatus({ status: 'notUpToDate', requiredDay: missingRequired.requiredDay });
-    }
-    const latestRequired = allCodeSets
-      .filter((cs) => cs.criteria?.some((c) => c.id === criterion.criterion.id) && cs.requiredDay)
-      .filter((cs) => criterionCodeSetIds.has(cs.id))
-      .sort((a, b) => (a.requiredDay > b.requiredDay ? -1 : 1))[0];
-    setCodeSetStatus({ status: 'upToDate', requiredDay: latestRequired?.requiredDay });
-  }, [allCodeSets, criterion]);
+    const missingDays = relevantCodeSets
+      .filter((cs) => !criterion.codeSets.some((ccs) => ccs.codeSet.id === cs.id))
+      .map((cs) => cs.requiredDay)
+      .sort((a, b) => (a < b ? -1 : 1));
+    setEndDay(missingDays[0]);
+  }, [criterion, relevantCodeSets]);
 
-  if (isLoading || isError || !codeSetStatus) { return <CircularProgress />; }
+  if (isLoading || isError) { return <CircularProgress />; }
 
   if (hasAnyRole(['chpl-admin', 'chpl-onc', 'chpl-onc-acb'])) {
     return (
@@ -87,46 +53,12 @@ function ChplCodeSetIndicator({ criterion }) {
 
   return (
     <Box display="flex" alignItems="center" gridGap={8}>
-      { codeSetStatus.status === 'upToDate'
-        && (
-          <>
-            <Chip
-              icon={<RadioButtonCheckedIcon />}
-              label="Up-to-date"
-              className={classes.upToDate}
-            />
-            <Typography variant="body2">
-              This criterion meets the current code set requirement.
-              { codeSetStatus.requiredDay && (
-                <>
-                  {' The required date for this code set is '}
-                  { getDisplayDateFormat(codeSetStatus.requiredDay) }
-                  {'.'}
-                </>
-              )}
-            </Typography>
-          </>
-        )}
-      { codeSetStatus.status === 'notUpToDate'
-        && (
-          <>
-            <Chip
-              icon={<RadioButtonUncheckedIcon />}
-              label="Not up-to-date"
-              className={classes.notUpToDate}
-            />
-            <Typography variant="body2">
-              This criterion&apos;s code set does not meet the requirement that took effect as of
-              { codeSetStatus.requiredDay && (
-                <>
-                  {' '}
-                  { getDisplayDateFormat(codeSetStatus.requiredDay) }
-                </>
-              )}
-              . Contact the developer for more information.
-            </Typography>
-          </>
-        )}
+      <Typography>
+        { endDay ? 'Update Required' : 'Current' }
+      </Typography>
+      <ChplUpdateIndicator
+        endDay={endDay}
+      />
     </Box>
   );
 }

--- a/src/app/components/listing/details/criteria/criterion-details-view.jsx
+++ b/src/app/components/listing/details/criteria/criterion-details-view.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import {
   Box,
   Card,
+  Chip,
   IconButton,
   List,
   ListItem,
@@ -16,10 +17,13 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import InfoIcon from '@material-ui/icons/Info';
+import RadioButtonCheckedIcon from '@material-ui/icons/RadioButtonChecked';
+import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
 import { arrayOf } from 'prop-types';
 
 import ChplReliedUponSoftwareView from './relied-upon-software/relied-upon-software-view';
 
+import { useFetchCodeSets } from 'api/standards';
 import {
   ChplEllipsis,
   ChplLink,
@@ -32,9 +36,24 @@ import {
   certificationResult,
   qmsStandard,
 } from 'shared/prop-types';
+import { getDisplayDateFormat } from 'services/date-util';
 import { palette } from 'themes';
 
 const useStyles = makeStyles({
+  upToDate: {
+    backgroundColor: palette.active,
+    color: palette.white,
+    '& .MuiChip-icon': {
+      color: palette.white,
+    },
+  },
+  notUpToDate: {
+    backgroundColor: palette.error,
+    color: palette.white,
+    '& .MuiChip-icon': {
+      color: palette.white,
+    },
+  },
   infoIcon: {
     float: 'right',
   },
@@ -57,7 +76,28 @@ function ChplCriterionDetailsView({
 }) {
   const { hasAnyRole, user } = useContext(UserContext);
   const { listing } = useContext(ListingContext);
+  const { data: allCodeSets } = useFetchCodeSets();
   const classes = useStyles();
+
+  const getCodeSetStatus = () => {
+    if (!allCodeSets || !criterion.codeSets) return null;
+    const criterionId = criterion.criterion.id;
+    const today = new Date().toISOString().split('T')[0];
+    const listingCodeSetIds = new Set(criterion.codeSets.map((cs) => cs.codeSet.id));
+    const applicableCodeSets = allCodeSets.filter(
+      (cs) => cs.criteria?.some((c) => c.id === criterionId) && cs.requiredDay,
+    );
+    const missingRequired = applicableCodeSets.find(
+      (cs) => cs.requiredDay <= today && !listingCodeSetIds.has(cs.id),
+    );
+    if (missingRequired) {
+      return { status: 'not-up-to-date', requiredDay: missingRequired.requiredDay };
+    }
+    const latestRequired = applicableCodeSets
+      .filter((cs) => listingCodeSetIds.has(cs.id))
+      .sort((a, b) => (a.requiredDay > b.requiredDay ? -1 : 1))[0];
+    return { status: 'up-to-date', requiredDay: latestRequired?.requiredDay };
+  };
 
   if (criterion.criterion.certificationEdition === '2011') {
     return null;
@@ -128,7 +168,7 @@ function ChplCriterionDetailsView({
                     <TableCell><ChplReliedUponSoftwareView sw={criterion.additionalSoftware} /></TableCell>
                   </TableRow>
                 )}
-              { criterion.success && criterion.criterion.attributes?.codeSet && hasAnyRole(['chpl-admin', 'chpl-onc', 'chpl-onc-acb'])
+              { criterion.success && criterion.criterion.attributes?.codeSet
                 && (
                   <TableRow key="codeSet">
                     <TableCell component="th" scope="row">
@@ -142,14 +182,64 @@ function ChplCriterionDetailsView({
                       Code Sets
                     </TableCell>
                     <TableCell>
-                      <List>
-                        { criterion.codeSets.map((cs) => (
-                          <ListItem key={cs.id}>
-                            { cs.codeSet.name }
-                          </ListItem>
-                        ))}
-                      </List>
-                      { criterion.codeSets?.length === 0 && 'None' }
+                      { hasAnyRole(['chpl-admin', 'chpl-onc', 'chpl-onc-acb']) && (
+                        <>
+                          <List>
+                            { criterion.codeSets.map((cs) => (
+                              <ListItem key={cs.id}>
+                                { cs.codeSet.name }
+                              </ListItem>
+                            ))}
+                          </List>
+                          { criterion.codeSets?.length === 0 && 'None' }
+                        </>
+                      )}
+                      { !hasAnyRole(['chpl-admin', 'chpl-onc', 'chpl-onc-acb']) && (() => {
+                        const codeSetStatus = getCodeSetStatus();
+                        if (!codeSetStatus) return null;
+                        return (
+                          <Box display="flex" alignItems="center" gridGap={8}>
+                            { codeSetStatus.status === 'up-to-date' && (
+                              <>
+                                <Chip
+                                  icon={<RadioButtonCheckedIcon />}
+                                  label="Up-to-date"
+                                  className={classes.upToDate}
+                                />
+                                <Typography variant="body2">
+                                  This listing meets the current code set requirement.
+                                  { codeSetStatus.requiredDay && (
+                                    <>
+                                      {' The required date for this criteria is '}
+                                      { getDisplayDateFormat(codeSetStatus.requiredDay) }
+                                      {'.'}
+                                    </>
+                                  )}
+                                </Typography>
+                              </>
+                            )}
+                            { codeSetStatus.status === 'not-up-to-date' && (
+                              <>
+                                <Chip
+                                  icon={<RadioButtonUncheckedIcon />}
+                                  label="Not up-to-date"
+                                  className={classes.notUpToDate}
+                                />
+                                <Typography variant="body2">
+                                  {'This listing\u2019s code set does not meet the requirement that took effect'}
+                                  { codeSetStatus.requiredDay && (
+                                    <>
+                                      {' '}
+                                      { getDisplayDateFormat(codeSetStatus.requiredDay) }
+                                    </>
+                                  )}
+                                  {'. Contact the developer for more information.'}
+                                </Typography>
+                              </>
+                            )}
+                          </Box>
+                        );
+                      })()}
                     </TableCell>
                   </TableRow>
                 )}

--- a/src/app/components/listing/details/criteria/criterion-details-view.jsx
+++ b/src/app/components/listing/details/criteria/criterion-details-view.jsx
@@ -36,7 +36,7 @@ import {
   certificationResult,
   qmsStandard,
 } from 'shared/prop-types';
-import { getDisplayDateFormat } from 'services/date-util';
+import { getDisplayDateFormat, jsJoda } from 'services/date-util';
 import { palette } from 'themes';
 
 const useStyles = makeStyles({
@@ -76,13 +76,13 @@ function ChplCriterionDetailsView({
 }) {
   const { hasAnyRole, user } = useContext(UserContext);
   const { listing } = useContext(ListingContext);
-  const { data: allCodeSets } = useFetchCodeSets();
+  const { data: allCodeSets, isError, isLoading } = useFetchCodeSets();
   const classes = useStyles();
 
   const getCodeSetStatus = () => {
     if (!allCodeSets || !criterion.codeSets) return null;
     const criterionId = criterion.criterion.id;
-    const today = new Date().toISOString().split('T')[0];
+    const today = jsJoda.LocalDate.now(jsJoda.ZoneId.of('America/New_York')).toString();
     const listingCodeSetIds = new Set(criterion.codeSets.map((cs) => cs.codeSet.id));
     const applicableCodeSets = allCodeSets.filter(
       (cs) => cs.criteria?.some((c) => c.id === criterionId) && cs.requiredDay,
@@ -97,6 +97,73 @@ function ChplCriterionDetailsView({
       .filter((cs) => listingCodeSetIds.has(cs.id))
       .sort((a, b) => (a.requiredDay > b.requiredDay ? -1 : 1))[0];
     return { status: 'up-to-date', requiredDay: latestRequired?.requiredDay };
+  };
+
+  const getCodeSetDisplayValue = () => {
+    if (isLoading) {
+      return <Typography variant="body2">Loading...</Typography>;
+    }
+    if (isError) {
+      return null;
+    }
+    if (hasAnyRole(['chpl-admin', 'chpl-onc', 'chpl-onc-acb'])) {
+      return (
+        <>
+          <List>
+            { criterion.codeSets.map((cs) => (
+              <ListItem key={cs.id}>
+                { cs.codeSet.name }
+              </ListItem>
+            ))}
+          </List>
+          { criterion.codeSets?.length === 0 && 'None' }
+        </>
+      );
+    }
+    const codeSetStatus = getCodeSetStatus();
+    if (!codeSetStatus) return null;
+    return (
+      <Box display="flex" alignItems="center" gridGap={8}>
+        { codeSetStatus.status === 'up-to-date' && (
+          <>
+            <Chip
+              icon={<RadioButtonCheckedIcon />}
+              label="Up-to-date"
+              className={classes.upToDate}
+            />
+            <Typography variant="body2">
+              This listing meets the current code set requirement.
+              { codeSetStatus.requiredDay && (
+                <>
+                  {' The required date for this criteria is '}
+                  { getDisplayDateFormat(codeSetStatus.requiredDay) }
+                  {'.'}
+                </>
+              )}
+            </Typography>
+          </>
+        )}
+        { codeSetStatus.status === 'not-up-to-date' && (
+          <>
+            <Chip
+              icon={<RadioButtonUncheckedIcon />}
+              label="Not up-to-date"
+              className={classes.notUpToDate}
+            />
+            <Typography variant="body2">
+              This listing&apos;s code set does not meet the requirement that took effect
+              { codeSetStatus.requiredDay && (
+                <>
+                  {' '}
+                  { getDisplayDateFormat(codeSetStatus.requiredDay) }
+                </>
+              )}
+              . Contact the developer for more information.
+            </Typography>
+          </>
+        )}
+      </Box>
+    );
   };
 
   if (criterion.criterion.certificationEdition === '2011') {
@@ -182,64 +249,7 @@ function ChplCriterionDetailsView({
                       Code Sets
                     </TableCell>
                     <TableCell>
-                      { hasAnyRole(['chpl-admin', 'chpl-onc', 'chpl-onc-acb']) && (
-                        <>
-                          <List>
-                            { criterion.codeSets.map((cs) => (
-                              <ListItem key={cs.id}>
-                                { cs.codeSet.name }
-                              </ListItem>
-                            ))}
-                          </List>
-                          { criterion.codeSets?.length === 0 && 'None' }
-                        </>
-                      )}
-                      { !hasAnyRole(['chpl-admin', 'chpl-onc', 'chpl-onc-acb']) && (() => {
-                        const codeSetStatus = getCodeSetStatus();
-                        if (!codeSetStatus) return null;
-                        return (
-                          <Box display="flex" alignItems="center" gridGap={8}>
-                            { codeSetStatus.status === 'up-to-date' && (
-                              <>
-                                <Chip
-                                  icon={<RadioButtonCheckedIcon />}
-                                  label="Up-to-date"
-                                  className={classes.upToDate}
-                                />
-                                <Typography variant="body2">
-                                  This listing meets the current code set requirement.
-                                  { codeSetStatus.requiredDay && (
-                                    <>
-                                      {' The required date for this criteria is '}
-                                      { getDisplayDateFormat(codeSetStatus.requiredDay) }
-                                      {'.'}
-                                    </>
-                                  )}
-                                </Typography>
-                              </>
-                            )}
-                            { codeSetStatus.status === 'not-up-to-date' && (
-                              <>
-                                <Chip
-                                  icon={<RadioButtonUncheckedIcon />}
-                                  label="Not up-to-date"
-                                  className={classes.notUpToDate}
-                                />
-                                <Typography variant="body2">
-                                  {'This listing\u2019s code set does not meet the requirement that took effect'}
-                                  { codeSetStatus.requiredDay && (
-                                    <>
-                                      {' '}
-                                      { getDisplayDateFormat(codeSetStatus.requiredDay) }
-                                    </>
-                                  )}
-                                  {'. Contact the developer for more information.'}
-                                </Typography>
-                              </>
-                            )}
-                          </Box>
-                        );
-                      })()}
+                      { getCodeSetDisplayValue() }
                     </TableCell>
                   </TableRow>
                 )}

--- a/src/app/components/listing/details/criteria/criterion-details-view.jsx
+++ b/src/app/components/listing/details/criteria/criterion-details-view.jsx
@@ -133,7 +133,7 @@ function ChplCriterionDetailsView({
                 && (
                   <TableRow key="codeSet">
                     <TableCell component="th" scope="row">
-                      <ChplTooltip title="Complies with the month/year Code set for this criterion.">
+                      <ChplTooltip title="Meets current code set requirement.">
                         <IconButton className={classes.infoIcon}>
                           <InfoIcon
                             className={classes.infoIconColor}

--- a/src/app/components/listing/details/criteria/criterion-details-view.jsx
+++ b/src/app/components/listing/details/criteria/criterion-details-view.jsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import {
   Box,
   Card,
-  Chip,
   IconButton,
   List,
   ListItem,
@@ -17,13 +16,11 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import InfoIcon from '@material-ui/icons/Info';
-import RadioButtonCheckedIcon from '@material-ui/icons/RadioButtonChecked';
-import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
 import { arrayOf } from 'prop-types';
 
+import ChplCodeSetIndicator from './code-set-indicator/code-set-indicator';
 import ChplReliedUponSoftwareView from './relied-upon-software/relied-upon-software-view';
 
-import { useFetchCodeSets } from 'api/standards';
 import {
   ChplEllipsis,
   ChplLink,
@@ -36,24 +33,9 @@ import {
   certificationResult,
   qmsStandard,
 } from 'shared/prop-types';
-import { getDisplayDateFormat, jsJoda } from 'services/date-util';
 import { palette } from 'themes';
 
 const useStyles = makeStyles({
-  upToDate: {
-    backgroundColor: palette.active,
-    color: palette.white,
-    '& .MuiChip-icon': {
-      color: palette.white,
-    },
-  },
-  notUpToDate: {
-    backgroundColor: palette.error,
-    color: palette.white,
-    '& .MuiChip-icon': {
-      color: palette.white,
-    },
-  },
   infoIcon: {
     float: 'right',
   },
@@ -74,97 +56,9 @@ function ChplCriterionDetailsView({
   qmsStandards,
   accessibilityStandards,
 }) {
-  const { hasAnyRole, user } = useContext(UserContext);
+  const { user } = useContext(UserContext);
   const { listing } = useContext(ListingContext);
-  const { data: allCodeSets, isError, isLoading } = useFetchCodeSets();
   const classes = useStyles();
-
-  const getCodeSetStatus = () => {
-    if (!allCodeSets || !criterion.codeSets) return null;
-    const criterionId = criterion.criterion.id;
-    const today = jsJoda.LocalDate.now(jsJoda.ZoneId.of('America/New_York')).toString();
-    const listingCodeSetIds = new Set(criterion.codeSets.map((cs) => cs.codeSet.id));
-    const applicableCodeSets = allCodeSets.filter(
-      (cs) => cs.criteria?.some((c) => c.id === criterionId) && cs.requiredDay,
-    );
-    const missingRequired = applicableCodeSets.find(
-      (cs) => cs.requiredDay <= today && !listingCodeSetIds.has(cs.id),
-    );
-    if (missingRequired) {
-      return { status: 'not-up-to-date', requiredDay: missingRequired.requiredDay };
-    }
-    const latestRequired = applicableCodeSets
-      .filter((cs) => listingCodeSetIds.has(cs.id))
-      .sort((a, b) => (a.requiredDay > b.requiredDay ? -1 : 1))[0];
-    return { status: 'up-to-date', requiredDay: latestRequired?.requiredDay };
-  };
-
-  const getCodeSetDisplayValue = () => {
-    if (isLoading) {
-      return <Typography variant="body2">Loading...</Typography>;
-    }
-    if (isError) {
-      return null;
-    }
-    if (hasAnyRole(['chpl-admin', 'chpl-onc', 'chpl-onc-acb'])) {
-      return (
-        <>
-          <List>
-            { criterion.codeSets.map((cs) => (
-              <ListItem key={cs.id}>
-                { cs.codeSet.name }
-              </ListItem>
-            ))}
-          </List>
-          { criterion.codeSets?.length === 0 && 'None' }
-        </>
-      );
-    }
-    const codeSetStatus = getCodeSetStatus();
-    if (!codeSetStatus) return null;
-    return (
-      <Box display="flex" alignItems="center" gridGap={8}>
-        { codeSetStatus.status === 'up-to-date' && (
-          <>
-            <Chip
-              icon={<RadioButtonCheckedIcon />}
-              label="Up-to-date"
-              className={classes.upToDate}
-            />
-            <Typography variant="body2">
-              This listing meets the current code set requirement.
-              { codeSetStatus.requiredDay && (
-                <>
-                  {' The required date for this criteria is '}
-                  { getDisplayDateFormat(codeSetStatus.requiredDay) }
-                  {'.'}
-                </>
-              )}
-            </Typography>
-          </>
-        )}
-        { codeSetStatus.status === 'not-up-to-date' && (
-          <>
-            <Chip
-              icon={<RadioButtonUncheckedIcon />}
-              label="Not up-to-date"
-              className={classes.notUpToDate}
-            />
-            <Typography variant="body2">
-              This listing&apos;s code set does not meet the requirement that took effect
-              { codeSetStatus.requiredDay && (
-                <>
-                  {' '}
-                  { getDisplayDateFormat(codeSetStatus.requiredDay) }
-                </>
-              )}
-              . Contact the developer for more information.
-            </Typography>
-          </>
-        )}
-      </Box>
-    );
-  };
 
   if (criterion.criterion.certificationEdition === '2011') {
     return null;
@@ -249,7 +143,9 @@ function ChplCriterionDetailsView({
                       Code Sets
                     </TableCell>
                     <TableCell>
-                      { getCodeSetDisplayValue() }
+                      <ChplCodeSetIndicator
+                        criterion={criterion}
+                      />
                     </TableCell>
                   </TableRow>
                 )}

--- a/src/app/components/listing/details/criteria/criterion.jsx
+++ b/src/app/components/listing/details/criteria/criterion.jsx
@@ -56,25 +56,9 @@ const useStyles = makeStyles({
     flexWrap: 'wrap',
     alignItems: 'center',
   },
-  iconSpacing: {
-    marginLeft: '4px',
-  },
-  pendingChip: {
-    fontSize: '.7rem',
-    backgroundColor: '#3e0d59',
-    color: palette.white,
-  },
-  stagedChip: {
-    fontSize: '.7rem',
-    backgroundColor: '#0d5928',
-    color: palette.white,
-  },
   criterionNumber: {
     textTransform: 'none',
     fontWeight: '700',
-  },
-  editCriterion: {
-    margin: '8px 0px',
   },
   rotate: {
     transform: 'rotate(180deg)',

--- a/src/app/components/util/update-indicator.jsx
+++ b/src/app/components/util/update-indicator.jsx
@@ -33,9 +33,9 @@ const useStyles = makeStyles({
 });
 
 function ChplUpdateIndicator({
-  requiredDay = undefined,
-  endDay = undefined,
   additionalInformation = undefined,
+  endDay = undefined,
+  requiredDay = undefined,
 }) {
   const { criterion } = useContext(CriterionContext);
   const { listing } = useContext(ListingContext);
@@ -128,7 +128,7 @@ function ChplUpdateIndicator({
 export default ChplUpdateIndicator;
 
 ChplUpdateIndicator.propTypes = {
-  requiredDay: string,
-  endDay: string,
   additionalInformation: string,
+  endDay: string,
+  requiredDay: string,
 };


### PR DESCRIPTION
This pull request enhances the display of code set information in the `ChplCriterionDetailsView` component, especially for users without admin roles. It introduces a visual indicator for code set compliance, improves the code set status calculation, and refines the UI for different user roles.

**Code Set Status Display Improvements:**

* Added a visual status indicator using `Chip` components with "Up-to-date" and "Not up-to-date" labels, including icons and explanatory text, for non-admin users viewing code set requirements.
* Implemented the `getCodeSetStatus` function to determine if the listing's code sets are current with requirements, factoring in required dates and applicable code sets.
* Applied custom styles for the code set status indicators to visually distinguish up-to-date and not-up-to-date states.

**Role-Based UI Adjustments:**

* Refactored the code set display so that only admin roles see the detailed list of code sets, while other users see the new status indicator and message. [[1]](diffhunk://#diff-88c3971258571ddd1d73fb8c7f5f73be13f7c977e45fed5efb8e27d4bbfb4375L131-R171) [[2]](diffhunk://#diff-88c3971258571ddd1d73fb8c7f5f73be13f7c977e45fed5efb8e27d4bbfb4375R185-R186)

**Dependency and Utility Updates:**

* Added necessary imports for new Material-UI components, icons, and utility functions to support the updated UI and status logic. [[1]](diffhunk://#diff-88c3971258571ddd1d73fb8c7f5f73be13f7c977e45fed5efb8e27d4bbfb4375R5) [[2]](diffhunk://#diff-88c3971258571ddd1d73fb8c7f5f73be13f7c977e45fed5efb8e27d4bbfb4375R20-R26)

These changes improve the clarity and user experience around code set compliance for different types of users.[#OCD-5234]